### PR TITLE
added analog temp sensor

### DIFF
--- a/tkgpio/tkgpio.py
+++ b/tkgpio/tkgpio.py
@@ -33,7 +33,7 @@ class TkCircuit(metaclass=SingletonMeta):
             "light_sensors": [],
             "adc": None,
             "infrared_receiver": None, "infrared_emitter": None,
-            "labels": [],
+            "labels": [],"rgb_leds":[],
         }
         
         default_setup.update(setup)
@@ -55,15 +55,21 @@ class TkCircuit(metaclass=SingletonMeta):
         self._outputs += [self.add_device(TkBuzzer, parameters) for parameters in setup["buzzers"]]
         self._outputs += [self.add_device(TkMotor, parameters) for parameters in setup["motors"]]
         self._outputs += [self.add_device(TkServo, parameters) for parameters in setup["servos"]]
+        self._outputs += [self.add_device(TkRGBLED, parameters) for parameters in setup["rgb_leds"]]
         
         self._lcds = [self.add_device(TkLCD, parameters) for parameters in setup["lcds"]]
         
         if setup["adc"] != None:
             spi = TkSPI(setup["adc"]["mcp_chip"])
-            for parameters in setup["adc"]["potenciometers"]:
-                parameters["tk_spi"] = spi
-                self.add_device(TkPotentiometer, parameters)
-                
+            if setup["adc"]["potenciometers"] !=None:
+                for parameters in setup["adc"]["potenciometers"]:
+                    parameters["tk_spi"] = spi
+                    self.add_device(TkPotentiometer, parameters)
+            if setup["adc"]["temp_sensors"] !=None:
+                for parameters in setup["adc"]["temp_sensors"]:
+                    parameters["tk_spi"] = spi
+                    self.add_device(TkTempSensor, parameters)    
+        
         for parameters in setup["buttons"]:
             self.add_device(TkButton, parameters)
             
@@ -262,7 +268,62 @@ class TkLED(TkDevice):
             
             self._redraw()
             
-
+class TkRGBLED(TkDevice):
+    image = None
+    
+    def __init__(self, root, x, y, name, rpin, gpin, bpin):
+        super().__init__(root, x, y, name)
+        
+        self._rpin = Device.pin_factory.pin(rpin)
+        self._gpin = Device.pin_factory.pin(gpin)
+        self._bpin = Device.pin_factory.pin(bpin)
+        
+        self._previous_state = None
+        self._current_state = (self._rpin.state, self._gpin.state, self._bpin.state)
+        
+        TkRGBLED.image = self._set_image_for_state("rgb_led_off.png", "off", (19, 30))
+        self._create_main_widget(Label, "off",20)
+        
+    def update(self):
+        self._current_state=(self._rpin.state, self._gpin.state, self._bpin.state)
+        if self._previous_state != self._current_state:
+            if (isinstance(self._rpin.state,bool)):
+                if (self._rpin.state==True):
+                    r=1.0
+                else:
+                    r=0.0
+            else:
+                r=self._rpin.state
+            if (isinstance(self._gpin.state,bool)):
+                if (self._gpin.state==True):
+                    g=1.0
+                else:
+                    g=0.0
+            else:
+                g=self._gpin.state
+            if (isinstance(self._bpin.state,bool)):
+                if (self._bpin.state==True):
+                    b=1.0
+                else:
+                    b=0.0
+            else:
+                b=self._bpin.state
+            r=round(r*255)
+            g=round(g*255)
+            b=round(b*255)
+            background=TkRGBLED.image.convert("RGBA")
+            overlay=Image.new("RGBA",background.size,(255,255,255,0))
+            draw=ImageDraw.Draw(overlay)
+            draw.ellipse([2,0,16,14],(r,g,b),(0,0,0),1)
+            draw.rectangle([2,7,16,14],(r,g,b),(0,0,0),1)
+            draw.rectangle([3,7,15,14],(r,g,b),None,1)
+            draw.rectangle([0,16,18,20],(r,g,b),(0,0,0),1)
+            out = Image.alpha_composite(background, overlay)
+            self._change_widget_image(out)
+             
+            self._previous_state = self._current_state           
+            self._redraw()
+            
 class TkMotor(TkDevice):
     _image = None
     
@@ -533,7 +594,22 @@ class TkPotentiometer(TkDevice):
         
     def _scale_changed(self, value):
         self._tk_spi.mock_spi.set_value_for_channel(float(value), self._channel)
-            
+
+class TkTempSensor(TkDevice):
+    def __init__(self, root, x, y, name, tk_spi, channel):
+        super().__init__(root, x, y, name)
+        
+        self._tk_spi = tk_spi
+        self._channel = channel
+        
+        self._scale = Scale(root, from_=0, to=1, resolution=0.01, showvalue=0,
+            orient=HORIZONTAL, command=self._scale_changed, sliderlength=20, length=150, highlightthickness = 0, background="white")
+        self._scale.place(x=x, y=y)
+        self._scale.set(0.5)
+        self._scale_changed(self._scale.get())
+        
+    def _scale_changed(self, value):
+        self._tk_spi.mock_spi.set_value_for_channel(float(value), self._channel)
             
 class TkInfraredReceiver(TkDevice, metaclass=SingletonMeta):
 
@@ -630,3 +706,5 @@ class TkInfraredEmitter(TkDevice, metaclass=SingletonMeta):
     def _turn_off_emitter(self):
         self._change_widget_image("off")
         self._timer = None
+
+


### PR DESCRIPTION
this change adds an analog temp sensor to tkgpio.py which mimics the same way that the potentiometer was implemented (using mcp adc). Below is a demonstration of how temp sensor could be added to circuit.

"adc": {
       "mcp_chip": 3002,
       "potenciometers": [
       {"x": 175, "y": 375, "name": "Potentiometer on ADC0", "channel": 0}
       ],
       "temp_sensors": [
        {"x": 350, "y": 375, "name": "Temp Sensor on ADC1", "channel": 1}
        ]
    }

This requires that both "potenciometers" and "temp_sensors" be always present, but that if either is not in use then none should be listed within the square brackets. For example, below would implement 0 pots and 1 temp sensor...

"adc": {
       "mcp_chip": 3002,
       "potenciometers": [
       
       ],
       "temp_sensors": [
        {"x": 350, "y": 375, "name": "Temp Sensor on ADC1", "channel": 1}
        ]
    }